### PR TITLE
Games names options : top screen and per game

### DIFF
--- a/_inc/variables/lang-default.xml
+++ b/_inc/variables/lang-default.xml
@@ -11,6 +11,9 @@
 		<subset.options.yes>yes</subset.options.yes>
 		<subset.options.no>no</subset.options.no>
 
+		<subset.options.pergame>pergame</subset.options.pergame>
+		<subset.options.topscreen>topscreen</subset.options.topscreen>
+
 		<subset.options.enabled>enabled</subset.options.enabled>
 		<subset.options.disabled>disabled</subset.options.disabled>
 

--- a/_inc/xml/grid.xml
+++ b/_inc/xml/grid.xml
@@ -128,6 +128,7 @@
 		>
 
 			<visible ifSubset="gridGameName:no">false</visible>
+			<visible ifSubset="gridGameName:topscreen">false</visible>
 
 		</text>
 
@@ -138,8 +139,53 @@
 		>
 
 			<visible ifSubset="gridGameName:no">false</visible>
+			<visible ifSubset="gridGameName:topscreen">false</visible>
 
 		</text>
+
+		<!-- game name-->
+		<text name="md_name">
+			<origin>0.5 0.5</origin>
+			<pos>0.55 0.025</pos>
+			<size>1</size>
+			<fontSize>0.025</fontSize>
+			<fontPath>"./../fonts/${f.def}"</fontPath>
+			<alignment>left</alignment>
+			<singleLineScroll>true</singleLineScroll>
+			<w>0.35</w>
+			<autoScroll>horizontal</autoScroll>
+			<autoScrollDelay>0.01</autoScrollDelay>
+			<zIndex>5000</zIndex>
+			<visible ifSubset="gridGameName:no">false</visible>
+			<visible ifSubset="gridGameName:pergame">false</visible>
+		</text>
+		<!-- release date-->
+		<datetime name="md_releasedate">
+			<origin>0.5 0.5</origin>
+			<pos>0.16 0.025</pos>
+			<size>0.1 0.035</size>
+			<fontSize>0.025</fontSize>
+			<fontPath>"./../fonts/${f.def}"</fontPath>
+			<format>%Y</format>
+			<color>dddddd</color>
+			<alignment>right</alignment>
+			<zIndex>5000</zIndex>
+			<visible ifSubset="gridGameName:no">false</visible>
+			<visible ifSubset="gridGameName:pergame">false</visible>
+		</datetime>
+		<!-- rating-->
+		<rating name="md_rating">
+			<origin>0.5 0.5</origin>
+			<pos>0.25 0.025</pos>
+			<size>0.05 0.03</size>
+			<color>FFFF00</color>
+			<unfilledColor>808080</unfilledColor>
+			<unfilledPath>:/star_filled.svg</unfilledPath>
+			<horizontalAlignment>left</horizontalAlignment>
+			<zIndex>5000</zIndex>
+			<visible ifSubset="gridGameName:no">false</visible>
+			<visible ifSubset="gridGameName:pergame">false</visible>
+		</rating>
 
 		<image name="gridtile.favorite"
 		

--- a/theme.xml
+++ b/theme.xml
@@ -230,7 +230,8 @@
 	>
 	
 		<include name="no" displayName="${subset.options.no}" />
-		<include name="yes" displayName="${subset.options.yes}" />
+		<include name="pergame" displayName="${subset.options.pergame}" />
+		<include name="topscreen" displayName="${subset.options.topscreen}" />
 	
 	</subset>
 


### PR DESCRIPTION
Tried my best to add those options as cleanly as possible, tested on my 35xx + with no issue.

Date, rating and name could get a layout polish as you wish ;)

![topscreen](https://github.com/user-attachments/assets/43d5296c-9f5d-4aac-9a20-a09131bc169f)

Again, beautiful theme and interesting way of building it, i learned a lot, thanks !